### PR TITLE
登録者のプロフィール編集で「正解」を登録できるようにした

### DIFF
--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -22,6 +22,6 @@ class UserProfilesController < ApplicationController
   private
 
   def user_profile_params
-    params.require(:user_profile).permit(:first_name, :last_name)
+    params.require(:user_profile).permit(:last_name, :first_name, :answer_name)
   end
 end

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -1,3 +1,9 @@
 class UserProfile < ActiveRecord::Base
   belongs_to :user
+  validates :first_name, length: { maximum: 30 }
+  validates :first_name, presence: true
+  validates :last_name, length: { maximum: 30 }
+  validates :last_name, presence: true
+  validates :answer_name, length: { maximum: 30 }
+  validates :answer_name, presence: true
 end

--- a/app/views/user_profiles/edit.html.erb
+++ b/app/views/user_profiles/edit.html.erb
@@ -1,5 +1,6 @@
 <%= form_for @user_profile do |f| %>
-  <%= f.text_field :first_name %>
   <%= f.text_field :last_name %>
+  <%= f.text_field :first_name %>
+  <%= f.text_field :answer_name %>
   <%= f.submit %>
 <% end %>

--- a/app/views/user_profiles/show.html.erb
+++ b/app/views/user_profiles/show.html.erb
@@ -1,2 +1,3 @@
-<%= @user_profile.first_name %>
 <%= @user_profile.last_name %>
+<%= @user_profile.first_name %>
+<%= @user_profile.answer_name %>

--- a/db/migrate/20150805074719_add_answer_name_to_user_profile.rb
+++ b/db/migrate/20150805074719_add_answer_name_to_user_profile.rb
@@ -1,0 +1,5 @@
+class AddAnswerNameToUserProfile < ActiveRecord::Migration
+  def change
+    add_column :user_profiles , :answer_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150804080322) do
+ActiveRecord::Schema.define(version: 20150805074719) do
 
   create_table "user_profiles", force: :cascade do |t|
-    t.integer  "user_id",    limit: 4
-    t.string   "first_name", limit: 255, null: false
-    t.string   "last_name",  limit: 255, null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.integer  "user_id",     limit: 4
+    t.string   "first_name",  limit: 255, null: false
+    t.string   "last_name",   limit: 255, null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.string   "answer_name", limit: 255
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/user_profiles.rb
+++ b/spec/factories/user_profiles.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :user_profile do
-    first_name     { Forgery('name').first_name }
-    last_name      { Forgery('name').last_name  }
+    last_name       { Forgery('name').last_name }
+    first_name      { Forgery('name').first_name }
+    answer_name     { Forgery('name').name }
   end
 end

--- a/spec/features/user_profiles_spec.rb
+++ b/spec/features/user_profiles_spec.rb
@@ -10,30 +10,38 @@ feature '登録者のプロフィール', type: :feature do
     end
 
     scenario 'プロフィールが表示されること' do
-      expect(page).to have_content user_profile.last_name
       expect(page).to have_content user_profile.first_name
+      expect(page).to have_content user_profile.last_name
+      expect(page).to have_content user_profile.answer_name
     end
   end
 
   feature 'プロフィールの編集' do
     let!(:user_profile) { FactoryGirl.create :user_profile }
-    let!(:edited_first_name) { 'edited_first_name' }
-    let!(:edited_last_name) { 'edited_last_name' }
+    let!(:new_last_name) { Forgery('name').last_name }
+    let!(:new_first_name) { Forgery('name').first_name }
+    let!(:new_answer_name) { Forgery('name').name }
 
     background do
       visit edit_user_profile_path(user_profile)
     end
 
     scenario 'プロフィールが編集できる' do
-      fill_in 'user_profile_first_name', with: edited_first_name
-      fill_in 'user_profile_last_name', with: edited_last_name
+      fill_in 'user_profile_last_name', with: new_last_name
+      fill_in 'user_profile_first_name', with: new_first_name
+      fill_in 'user_profile_answer_name', with: new_answer_name
       click_on 'Update User profile'
 
       expect(current_path).to eq user_profile_path(user_profile)
 
-      expect(page).to have_content edited_first_name
-      expect(page).to have_content edited_last_name
+      expect(page).to have_content new_last_name
+      expect(page).to have_content new_first_name
+      expect(page).to have_content new_answer_name
       expect(page).to have_content I18n.t('user_profiles.update.flash_edited')
+
+      expect(UserProfile.first.last_name).to eq new_last_name
+      expect(UserProfile.first.first_name).to eq new_first_name
+      expect(UserProfile.first.answer_name).to eq new_answer_name
     end
   end
 

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -2,4 +2,7 @@ require 'rails_helper'
 
 RSpec.describe UserProfile, type: :model do
   it { should belong_to(:user) }
+  it { should validate_length_of(:first_name).is_at_most(30) }
+  it { should validate_length_of(:last_name).is_at_most(30) }
+  it { should validate_length_of(:answer_name).is_at_most(30) }
 end


### PR DESCRIPTION
# 実装内容

- 姓名・正解の編集
  - モデルの作成・テスト追加
  - ビューの作成・テスト追加
  - コントローラーの作成