### PR TITLE
GoogleAPIログイン機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /log/*
 !/log/.keep
 /tmp
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ gem 'jquery-rails'
 gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
+gem 'devise'
+gem 'omniauth'
+gem 'omniauth-google-oauth2'
 
 group :test, :development do
   gem 'spring'
@@ -18,6 +21,7 @@ group :test, :development do
   gem 'pry-coolline'
   gem 'factory_girl'
   gem 'forgery'
+  gem 'dotenv-rails'
 
   gem 'web-console', '~> 2.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.2)
+    bcrypt (3.1.10)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -62,14 +63,28 @@ GEM
       unicode_utils (~> 1.4)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
+    devise (3.5.1)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 3.2.6, < 5)
+      responders
+      thread_safe (~> 0.1)
+      warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    dotenv (2.0.2)
+    dotenv-rails (2.0.2)
+      dotenv (= 2.0.2)
+      railties (~> 4.0)
     erubis (2.7.0)
     execjs (2.5.2)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
     forgery (0.6.0)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
+    hashie (3.4.2)
     i18n (0.7.0)
     jbuilder (2.3.1)
       activesupport (>= 3.0.0, < 5)
@@ -79,6 +94,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    jwt (1.5.1)
     loofah (2.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -88,9 +104,27 @@ GEM
     mini_portile (0.6.2)
     minitest (5.7.0)
     multi_json (1.11.2)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
     mysql2 (0.3.19)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    oauth2 (1.0.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (~> 1.2)
+    omniauth (1.2.2)
+      hashie (>= 1.2, < 4)
+      rack (~> 1.0)
+    omniauth-google-oauth2 (0.2.6)
+      omniauth (> 1.0)
+      omniauth-oauth2 (~> 1.1)
+    omniauth-oauth2 (1.3.1)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
+    orm_adapter (0.5.0)
     poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -137,6 +171,8 @@ GEM
     rake (10.4.2)
     rdoc (4.2.0)
       json (~> 1.4)
+    responders (2.1.0)
+      railties (>= 4.2.0, < 5)
     rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
     rspec-expectations (3.3.1)
@@ -187,6 +223,8 @@ GEM
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     unicode_utils (1.4.0)
+    warden (1.2.3)
+      rack (>= 1.0)
     web-console (2.2.1)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
@@ -205,11 +243,15 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 4.1.0)
   database_cleaner
+  devise
+  dotenv-rails
   factory_girl
   forgery
   jbuilder (~> 2.0)
   jquery-rails
   mysql2
+  omniauth
+  omniauth-google-oauth2
   poltergeist
   pry-byebug
   pry-coolline

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -1,0 +1,5 @@
+class PageController < ApplicationController
+  def index
+
+  end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,7 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def google_oauth2
+    @user = User.find_for_google_oauth2(request.env["omniauth.auth"])
+    flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "Google"
+    sign_in_and_redirect @user, :event => :authentication
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
 class User < ActiveRecord::Base
   has_one :user_profile
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable, :omniauthable
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,20 @@ class User < ActiveRecord::Base
   has_one :user_profile
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable
+
+  def self.find_for_google_oauth2(auth)
+    user = User.find_by(email: auth.info.email)
+
+    unless user
+      user = User.create(
+        name:     auth.info.name,
+        provider: auth.provider,
+        uid:      auth.uid,
+        email:    auth.info.email,
+        token:    auth.credentials.token,
+        password: Devise.friendly_token[0, 20]
+      )
+    end
+    user
+  end
 end

--- a/app/views/page/index.html.erb
+++ b/app/views/page/index.html.erb
@@ -1,0 +1,12 @@
+<h2>ユーザー情報</h2>
+
+<% if current_user then %>
+  <ul>
+    <li><%= current_user.name %></li>
+    <li><%= current_user.provider %></li>
+    <li><%= current_user.uid %></li>
+    <li><%= current_user.email %></li>
+  </ul>
+<% else %>
+  ログインしていません。<%= link_to 'Googleでログイン', user_omniauth_authorize_path(:google_oauth2) %>してください。
+<% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,269 @@
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` on Rails 4+ applications as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '1930cf2a26928a0e49f05258c1f101089e9052a88519c402516f657e2cb1f24458c9e1d1cd1d85128002f8d4a41ebe01ac84bee7a14d513699513c7132a58407'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication. The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 10. If
+  # using other encryptors, it sets how many times you want the password re-encrypted.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # encryptor), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 10
+
+  # Setup a pepper to generate the encrypted password.
+  # config.pepper = '8802ed1df91a60daf56e0bb130da3f5bbba7f338d074355e39f87a9a71fa2cd2c3c33f18a403d3937bd731c791695191c4a0c40a4d4ed5a2e7542d6cb6d7327e'
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day. Default is 0.days, meaning
+  # the user cannot access the website without confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 8..72
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  # config.email_regexp = /\A[^@]+@[^@]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # If true, expires auth token on session timeout.
+  # config.expire_auth_token_on_timeout = false
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another encryption algorithm besides bcrypt (default). You can use
+  # :sha1, :sha512 or encryptors from others authentication tools as :clearance_sha1,
+  # :authlogic_sha512 (then you should set stretches above to 20 for default behavior)
+  # and :restful_authentication_sha1 (then you should set stretches to 10, and copy
+  # REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  config.omniauth :google_oauth2,
+    Rails.application.secrets.google_client_id,
+    Rails.application.secrets.google_client_secret
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,60 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,3 +3,11 @@ ja:
     update:
       flash_edited: "編集しました。"
 
+  layouts:
+    application:
+      submit_profile: "プロフィール登録"
+
+  devise:
+    omniauth_callbacks:
+      success: "Googleでログインしました。"
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,6 @@ Rails.application.routes.draw do
     omniauth_callbacks: "users/omniauth_callbacks"
   }
   resources :user_profiles, only: [:show, :edit, :update]
+  resources :page, only: [:index]
+  root to: "page#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
+  devise_for :users, controllers: {
+    omniauth_callbacks: "users/omniauth_callbacks"
+  }
   resources :user_profiles, only: [:show, :edit, :update]
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,6 +12,8 @@
 
 development:
   secret_key_base: 31b7685bd1fa3bd7d9b11d15de16e158b782aa928c44831e7d2250d4af6eeffd292e0925726283808b7d3a1e3d1acbd82c48a7b27d994f6b19539c8c5bd9e000
+  google_client_id: <%= ENV["GOOGLE_CLIENT_ID"] %>
+  google_client_secret: <%= ENV["GOOGLE_CLIENT_SECRET"] %>
 
 test:
   secret_key_base: da3e1ee5f3b3ed2886f85cbf12a9e2e54b8ea1249583c921d3455f31fa57bf8c8b1632f125e076770407662d0167cdca2b4ff0a8ddb324643c7edbbd5c8bcdd1

--- a/db/migrate/20150810051524_add_devise_column_to_users.rb
+++ b/db/migrate/20150810051524_add_devise_column_to_users.rb
@@ -1,0 +1,28 @@
+class AddDeviseColumnToUsers < ActiveRecord::Migration
+  def change
+    ## Database authenticatable
+    add_column :users, :email, :string, null: false, default: ""
+    add_column :users, :encrypted_password, :string, null: false, default: ""
+
+    ## Recoverable
+    add_column :users, :reset_password_token, :string
+    add_column :users, :reset_password_sent_at, :datetime
+
+    ## Rememberable
+    add_column :users, :remember_created_at, :datetime
+
+    ## Trackable
+    add_column :users, :sign_in_count, :integer, default: 0, null: false
+    add_column :users, :current_sign_in_at, :datetime
+    add_column :users, :last_sign_in_at, :datetime
+    add_column :users, :current_sign_in_ip, :string
+    add_column :users, :last_sign_in_ip, :string
+
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+    add_column :users, :name, :string
+    add_column :users, :token, :string
+
+    add_index :users, :email, unique: true, length: { email: 191 }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150805074719) do
+ActiveRecord::Schema.define(version: 20150810051524) do
 
   create_table "user_profiles", force: :cascade do |t|
     t.integer  "user_id",     limit: 4
@@ -23,8 +23,22 @@ ActiveRecord::Schema.define(version: 20150805074719) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                                      null: false
+    t.datetime "updated_at",                                      null: false
+    t.string   "email",                  limit: 255, default: "", null: false
+    t.string   "encrypted_password",     limit: 255, default: "", null: false
+    t.string   "reset_password_token",   limit: 255
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          limit: 4,   default: 0,  null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string   "current_sign_in_ip",     limit: 255
+    t.string   "last_sign_in_ip",        limit: 255
+    t.string   "provider",               limit: 255
+    t.string   "uid",                    limit: 255
+    t.string   "name",                   limit: 255
+    t.string   "token",                  limit: 255
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,10 @@
 FactoryGirl.define do
   factory :user do
+    name      { Forgery(:basic).text }
+    provider  { :google_oauth2 }
+    uid       { Forgery(:basic).number }
+    email     { Forgery(:email).address }
+    token     { Forgery(:basic).encrypt }
+    password  { Devise.friendly_token[0, 20] }
   end
 end

--- a/spec/features/page_spec.rb
+++ b/spec/features/page_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+feature "top page", type: :feature do
+  feature 'トップページを表示' do
+    background do
+      visit root_path
+    end
+
+    context 'ログインしていない時' do
+      scenario 'Googleへのログインリンクが表示される' do
+        expect(page).to have_link 'Googleでログイン', user_omniauth_authorize_path(:google_oauth2)
+      end
+    end
+
+    context 'ログインしている時' do
+      include_context 'login_as_user'
+
+      scenario '自分のユーザー情報が表示される' do
+        expect(page).to have_content login_user.name
+        expect(page).to have_content login_user.provider
+        expect(page).to have_content login_user.uid
+        expect(page).to have_content login_user.email
+      end
+    end
+  end
+end

--- a/spec/features/users/omniauth_callbacks_spec.rb
+++ b/spec/features/users/omniauth_callbacks_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+# cf http://easyramble.com/request-spec-for-devise-omniatuh.html
+feature "Googleのアカウントを使いOmniauthでログインする" do
+  service = :google_oauth2
+  include_context 'setup_OmniAuth_config', service
+
+  subject { page }
+
+  background do
+    visit user_omniauth_authorize_path(service)
+  end
+
+  scenario 'ログインできている' do
+    expect(page.current_path).to eq root_path
+    expect(page).to have_content oauth_user.info.name
+    expect(page).to have_content oauth_user.provider
+    expect(page).to have_content oauth_user.uid
+    expect(page).to have_content oauth_user.email
+  end
+end

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe UserProfile, type: :model do
   it { should belong_to(:user) }
-  it { should ensure_length_of(:first_name).is_at_most(30) }
-  it { should ensure_length_of(:last_name).is_at_most(30) }
-  it { should ensure_length_of(:answer_name).is_at_most(30) }
+  it { should validate_length_of(:first_name).is_at_most(30) }
+  it { should validate_length_of(:last_name).is_at_most(30) }
+  it { should validate_length_of(:answer_name).is_at_most(30) }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,4 +2,26 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   it { should have_one(:user_profile) }
+
+  describe '.find_for_google_oauth2(auth)' do
+    include_context 'setup_OmniAuth_config', :google_oauth2
+    subject { described_class.find_for_google_oauth2(oauth_user) }
+
+    context 'when user exists' do
+      let!(:user) { FactoryGirl.create :user, email: oauth_user.info.email, uid: oauth_user.uid }
+      it { expect(subject.uid).to eq oauth_user.uid.to_s }
+      it { expect(subject.email).to eq oauth_user.info.email }
+      it 'create user' do
+        expect { subject }.to change{ User.count }.by(0)
+      end
+    end
+
+    context 'when user not exists' do
+      it { expect(subject.uid).to eq oauth_user.uid.to_s }
+      it { expect(subject.email).to eq oauth_user.info.email }
+      it 'create no user' do
+        expect { subject }.to change{ User.count }.by(1)
+      end
+    end
+ end
 end

--- a/spec/support/login_as_user.rb
+++ b/spec/support/login_as_user.rb
@@ -1,0 +1,5 @@
+shared_context 'login_as_user' do
+  include_context 'setup_OmniAuth_config', :google_oauth2
+  before { visit user_omniauth_authorize_path(provider: :google_oauth2) }
+  let!(:login_user) { User.find_by(uid: oauth_user.uid) }
+end

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -1,0 +1,28 @@
+shared_context "setup_OmniAuth_config" do |service|
+  before do
+    OmniAuth.config.test_mode = true
+
+    oauthinfo = {
+      uid:    Forgery('basic').number,
+      name:   Forgery('name').name,
+      email:  Forgery('email').address,
+      token:  Forgery('basic').encrypt,
+    }
+    OmniAuth.config.mock_auth[service] = OmniAuth::AuthHash.new(
+      {
+        name:       oauthinfo[:name],
+        provider:   service.to_s,
+        uid:        oauthinfo[:uid],
+        info: {
+          name:     oauthinfo[:name],
+          email:    oauthinfo[:email],
+        },
+        credentials: {
+          token:    oauthinfo[:token],
+        },
+      }
+    )
+  end
+
+  let(:oauth_user) { OmniAuth.config.mock_auth[service] }
+end


### PR DESCRIPTION
# 実装内容

- Devise、Omniauthで認証の基本を設定
- GoogleAPIでログインできるようにした

# 指摘への対応

- utf8mb4+Mysql でインデックスのlengthの長さ制限に対応。
- ログインテスト(login_as_user.spec.rb)の不備を修正。
- devise用の言語ファイル devise.ja.yml を追加
