### PR TITLE
プロフィール編集機能をGoogleAPIログイン情報に関連付け

### DIFF
--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -1,7 +1,5 @@
 class UserProfilesController < ApplicationController
-  def show
-    @user_profile = UserProfile.find(params[:id])
-  end
+  before_action :require_logged_in
 
   def edit
     @user_profile = UserProfile.find(params[:id])
@@ -13,7 +11,7 @@ class UserProfilesController < ApplicationController
     result = @user_profile.update_attributes(user_profile_params)
     if result
       flash[:notice] = I18n.t('user_profiles.update.flash_edited')
-      redirect_to user_profile_path(@user_profile)
+      redirect_to edit_user_profile_path(@user_profile)
     else
       render :edit
     end
@@ -23,5 +21,9 @@ class UserProfilesController < ApplicationController
 
   def user_profile_params
     params.require(:user_profile).permit(:last_name, :first_name, :answer_name)
+  end
+
+  def require_logged_in
+    redirect_to root_path unless current_user
   end
 end

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -20,7 +20,7 @@ class UserProfilesController < ApplicationController
   private
 
   def user_profile_params
-    params.require(:user_profile).permit(:last_name, :first_name, :answer_name)
+    params.require(:user_profile).permit(:answer_name)
   end
 
   def require_logged_in

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,14 +7,21 @@ class User < ActiveRecord::Base
     user = User.find_by(email: auth.info.email)
 
     unless user
-      user = User.create(
-        name:     auth.info.name,
-        provider: auth.provider,
-        uid:      auth.uid,
-        email:    auth.info.email,
-        token:    auth.credentials.token,
-        password: Devise.friendly_token[0, 20]
-      )
+      ActiveRecord::Base.transaction do
+        user = User.create!(
+          name:     auth.info.name,
+          provider: auth.provider,
+          uid:      auth.uid,
+          email:    auth.info.email,
+          token:    auth.credentials.token,
+          password: Devise.friendly_token[0, 20]
+        )
+        UserProfile.create!(
+          user_id: user.id,
+          last_name: 'a',
+          first_name: user.name,
+        )
+      end
     end
     user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,8 +18,6 @@ class User < ActiveRecord::Base
         )
         UserProfile.create!(
           user_id: user.id,
-          last_name: 'a',
-          first_name: user.name,
         )
       end
     end

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -1,9 +1,6 @@
 class UserProfile < ActiveRecord::Base
   belongs_to :user
+  delegate :name, to: :user
   validates :user_id, presence: true, numericality: true, uniqueness: true
-  validates :first_name, length: { maximum: 30 }
-  validates :first_name, presence: true
-  validates :last_name, length: { maximum: 30 }
-  validates :last_name, presence: true
   validates :answer_name, length: { maximum: 30 }
 end

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -1,9 +1,9 @@
 class UserProfile < ActiveRecord::Base
   belongs_to :user
+  validates :user_id, presence: true, numericality: true, uniqueness: true
   validates :first_name, length: { maximum: 30 }
   validates :first_name, presence: true
   validates :last_name, length: { maximum: 30 }
   validates :last_name, presence: true
   validates :answer_name, length: { maximum: 30 }
-  validates :answer_name, presence: true
 end

--- a/app/views/user_profiles/edit.html.erb
+++ b/app/views/user_profiles/edit.html.erb
@@ -1,8 +1,6 @@
 <%= form_for @user_profile do |f| %>
-  <%= f.label :last_name %>
-  <%= f.text_field :last_name %>
-  <%= f.label :first_name %>
-  <%= f.text_field :first_name %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
   <%= f.label :answer_name %>
   <%= f.text_field :answer_name %>
   <%= f.submit %>

--- a/app/views/user_profiles/edit.html.erb
+++ b/app/views/user_profiles/edit.html.erb
@@ -1,6 +1,9 @@
 <%= form_for @user_profile do |f| %>
+  <%= f.label :last_name %>
   <%= f.text_field :last_name %>
+  <%= f.label :first_name %>
   <%= f.text_field :first_name %>
+  <%= f.label :answer_name %>
   <%= f.text_field :answer_name %>
   <%= f.submit %>
 <% end %>

--- a/app/views/user_profiles/show.html.erb
+++ b/app/views/user_profiles/show.html.erb
@@ -1,3 +1,2 @@
-<%= @user_profile.last_name %>
-<%= @user_profile.first_name %>
+<%= @user_profile.name %>
 <%= @user_profile.answer_name %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,197 @@
+ja:
+  devise:
+    omniauth_callbacks:
+      success: "Googleでログインしました。"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+    prompts:
+      day: 日
+      hour: 時
+      minute: 分
+      month: 月
+      second: 秒
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      present: は入力しないでください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      record_invalid: バリデーションに失敗しました %{errors}
+      restrict_dependent_destroy: "%{record}が存在しているので削除できません"
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+      other_than: は%{count}以外の値にしてください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました。"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          gb: ギガバイト
+          kb: キロバイト
+          mb: メガバイト
+          tb: テラバイト
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: と
+      two_words_connector: と
+      words_connector: と
+  time:
+    am: 午前
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      short: "%y/%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,8 +6,3 @@ ja:
   layouts:
     application:
       submit_profile: "プロフィール登録"
-
-  devise:
-    omniauth_callbacks:
-      success: "Googleでログインしました。"
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     omniauth_callbacks: "users/omniauth_callbacks"
   }
-  resources :user_profiles, only: [:show, :edit, :update]
+  resources :user_profiles, only: [:edit, :update]
   resources :page, only: [:index]
   root to: "page#index"
 end

--- a/db/migrate/20150813044043_change_user_id_column_on_user_profiles.rb
+++ b/db/migrate/20150813044043_change_user_id_column_on_user_profiles.rb
@@ -1,0 +1,7 @@
+class ChangeUserIdColumnOnUserProfiles < ActiveRecord::Migration
+  def change
+    remove_column :user_profiles, :first_name
+    remove_column :user_profiles, :last_name
+    change_column_null :user_profiles, :user_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150810051524) do
+ActiveRecord::Schema.define(version: 20150813044043) do
 
   create_table "user_profiles", force: :cascade do |t|
-    t.integer  "user_id",     limit: 4
-    t.string   "first_name",  limit: 255, null: false
-    t.string   "last_name",   limit: 255, null: false
+    t.integer  "user_id",     limit: 4,   null: false
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
     t.string   "answer_name", limit: 255
@@ -40,5 +38,7 @@ ActiveRecord::Schema.define(version: 20150810051524) do
     t.string   "name",                   limit: 255
     t.string   "token",                  limit: 255
   end
+
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, length: {"email"=>191}, using: :btree
 
 end

--- a/spec/factories/user_profiles.rb
+++ b/spec/factories/user_profiles.rb
@@ -1,7 +1,5 @@
 FactoryGirl.define do
   factory :user_profile do
-    last_name       { Forgery('name').last_name }
-    first_name      { Forgery('name').first_name }
     answer_name     { Forgery('name').name }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,11 @@ FactoryGirl.define do
     email     { Forgery(:email).address }
     token     { Forgery(:basic).encrypt }
     password  { Devise.friendly_token[0, 20] }
+
+    trait :with_user_profile do
+      after(:create) do |user|
+        FactoryGirl.create :user_profile, user_id: user.id
+      end
+    end
   end
 end

--- a/spec/features/user_profiles_spec.rb
+++ b/spec/features/user_profiles_spec.rb
@@ -6,35 +6,25 @@ feature '登録者のプロフィール', type: :feature do
   feature 'プロフィールの編集' do
     let!(:user) { FactoryGirl.create :user, :with_user_profile }
     let!(:user_profile) { user.user_profile }
-    let!(:new_last_name) { Forgery('name').last_name }
-    let!(:new_first_name) { Forgery('name').first_name }
     let!(:new_answer_name) { Forgery('name').name }
 
     scenario 'プロフィールを表示できる' do
       visit edit_user_profile_path(user_profile)
 
-      expect(page).to have_field 'user_profile_last_name', login_user.user_profile.last_name
-      expect(page).to have_field 'user_profile_first_name', login_user.user_profile.first_name
       expect(page).to have_field 'user_profile_answer_name', login_user.user_profile.answer_name
     end
 
     scenario 'プロフィールが編集できる' do
       visit edit_user_profile_path(user_profile)
 
-      fill_in 'user_profile_last_name', with: new_last_name
-      fill_in 'user_profile_first_name', with: new_first_name
       fill_in 'user_profile_answer_name', with: new_answer_name
       click_on I18n.t('helpers.submit.update')
 
       expect(current_path).to eq edit_user_profile_path(user_profile)
 
       expect(page).to have_content I18n.t('user_profiles.update.flash_edited')
-      expect(page).to have_field 'user_profile_last_name', new_last_name
-      expect(page).to have_field 'user_profile_first_name', new_first_name
       expect(page).to have_field 'user_profile_answer_name', new_answer_name
 
-      expect(UserProfile.find(user_profile.id).last_name).to eq new_last_name
-      expect(UserProfile.find(user_profile.id).first_name).to eq new_first_name
       expect(UserProfile.find(user_profile.id).answer_name).to eq new_answer_name
     end
   end

--- a/spec/features/user_profiles_spec.rb
+++ b/spec/features/user_profiles_spec.rb
@@ -1,48 +1,41 @@
 require 'rails_helper'
 
 feature '登録者のプロフィール', type: :feature do
-
-  feature 'プロフィールの表示' do
-    let!(:user_profile) { FactoryGirl.create :user_profile }
-
-    background do
-      visit user_profile_path(user_profile)
-    end
-
-    scenario 'プロフィールが表示されること' do
-      expect(page).to have_content user_profile.first_name
-      expect(page).to have_content user_profile.last_name
-      expect(page).to have_content user_profile.answer_name
-    end
-  end
+  include_context 'login_as_user'
 
   feature 'プロフィールの編集' do
-    let!(:user_profile) { FactoryGirl.create :user_profile }
+    let!(:user) { FactoryGirl.create :user, :with_user_profile }
+    let!(:user_profile) { user.user_profile }
     let!(:new_last_name) { Forgery('name').last_name }
     let!(:new_first_name) { Forgery('name').first_name }
     let!(:new_answer_name) { Forgery('name').name }
 
-    background do
+    scenario 'プロフィールを表示できる' do
       visit edit_user_profile_path(user_profile)
+
+      expect(page).to have_field 'user_profile_last_name', login_user.user_profile.last_name
+      expect(page).to have_field 'user_profile_first_name', login_user.user_profile.first_name
+      expect(page).to have_field 'user_profile_answer_name', login_user.user_profile.answer_name
     end
 
     scenario 'プロフィールが編集できる' do
+      visit edit_user_profile_path(user_profile)
+
       fill_in 'user_profile_last_name', with: new_last_name
       fill_in 'user_profile_first_name', with: new_first_name
       fill_in 'user_profile_answer_name', with: new_answer_name
-      click_on 'Update User profile'
+      click_on I18n.t('helpers.submit.update')
 
-      expect(current_path).to eq user_profile_path(user_profile)
+      expect(current_path).to eq edit_user_profile_path(user_profile)
 
-      expect(page).to have_content new_last_name
-      expect(page).to have_content new_first_name
-      expect(page).to have_content new_answer_name
       expect(page).to have_content I18n.t('user_profiles.update.flash_edited')
+      expect(page).to have_field 'user_profile_last_name', new_last_name
+      expect(page).to have_field 'user_profile_first_name', new_first_name
+      expect(page).to have_field 'user_profile_answer_name', new_answer_name
 
-      expect(UserProfile.first.last_name).to eq new_last_name
-      expect(UserProfile.first.first_name).to eq new_first_name
-      expect(UserProfile.first.answer_name).to eq new_answer_name
+      expect(UserProfile.find(user_profile.id).last_name).to eq new_last_name
+      expect(UserProfile.find(user_profile.id).first_name).to eq new_first_name
+      expect(UserProfile.find(user_profile.id).answer_name).to eq new_answer_name
     end
   end
-
 end

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -2,7 +2,5 @@ require 'rails_helper'
 
 RSpec.describe UserProfile, type: :model do
   it { should belong_to(:user) }
-  it { should validate_length_of(:first_name).is_at_most(30) }
-  it { should validate_length_of(:last_name).is_at_most(30) }
   it { should validate_length_of(:answer_name).is_at_most(30) }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe User, type: :model do
     context 'when user not exists' do
       it { expect(subject.uid).to eq oauth_user.uid.to_s }
       it { expect(subject.email).to eq oauth_user.info.email }
-      it { expect(subject.user_profile.first_name).to eq oauth_user.name }
+      it { expect(subject.name).to eq oauth_user.name }
 
       it 'create user' do
-        expect { subject }.to change{ UserProfile.count }.by(1).and change{ User.count }.by(1)
+        expect { subject }.to change{ User.count }.by(1).and change{ UserProfile.count }.by(1)
       end
     end
  end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe User, type: :model do
       let!(:user) { FactoryGirl.create :user, email: oauth_user.info.email, uid: oauth_user.uid }
       it { expect(subject.uid).to eq oauth_user.uid.to_s }
       it { expect(subject.email).to eq oauth_user.info.email }
-      it 'create user' do
+      it 'create no user' do
         expect { subject }.to change{ User.count }.by(0)
       end
     end
@@ -19,8 +19,10 @@ RSpec.describe User, type: :model do
     context 'when user not exists' do
       it { expect(subject.uid).to eq oauth_user.uid.to_s }
       it { expect(subject.email).to eq oauth_user.info.email }
-      it 'create no user' do
-        expect { subject }.to change{ User.count }.by(1)
+      it { expect(subject.user_profile.first_name).to eq oauth_user.name }
+
+      it 'create user' do
+        expect { subject }.to change{ UserProfile.count }.by(1).and change{ User.count }.by(1)
       end
     end
  end


### PR DESCRIPTION
# 実装内容

- Googleの認証情報でユーザープロフィールを作成するようにした

#  指摘への対応

- (page) ( page ) など書き方の揺れやインデントを修正。
- 他のブランチとリベースできてなかった点を修正。
- モデルのユーザー情報生成でtransaction するように。
- devise.ja.yml を追加したコミットを分ける。
- user_profile.user_id にDB側でnot null 制約を追加
- user_profile.answer_name の バリデーション presence を外したことに関してコミットメッセージを追加
