### PR TITLE
回答履歴が記録されるようにする

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -1,5 +1,5 @@
 class PageController < ApplicationController
   def index
-
+    @start_button_enabled = UserProfile.new.answer_user.present?
   end
 end

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,16 +1,35 @@
 class QuizzesController < ApplicationController
   def show
-    @user_profile = UserProfile.all.sample
+    @answer_user_profile = UserProfile.new.answer_user
+
+    @total_correct = current_user.user_profile.total_correct
+    @total_incorrect = current_user.user_profile.total_incorrect
   end
 
   def answer
-    @user_profile = UserProfile.find(params[:answer_user_id])
+    @answer_user_profile = UserProfile.find(params[:answer_user_id])
 
-    if @user_profile.answer_name.eql? params[:answer_user_name]
-      flash[:notice] = '正解'
+    if @answer_user_profile.answer_name == params[:answer_user_name]
+      case_correct
     else
-      flash[:notice] = "不正解! 答えは#{@user_profile.answer_name.to_s}です。"
+      case_incorrect
     end
     redirect_to quiz_path
+  end
+
+  private
+
+  def case_correct
+    create_answer_history(true, params[:answer_user_name], current_user.user_profile.id, params[:answer_user_id])
+    flash[:notice] = '正解！'
+  end
+
+  def case_incorrect
+    create_answer_history(false, params[:answer_user_name], current_user.user_profile.id, params[:answer_user_id])
+    flash[:notice] = "不正解! 答えは#{@answer_user_profile.answer_name.to_s}です。"
+  end
+
+  def create_answer_history(correct, answer, user_profile_id, to_user_profile_id)
+    Answer.create!(correct: correct, answer: answer, user_profile_id: user_profile_id, to_user_profile_id: to_user_profile_id)
   end
 end

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -21,12 +21,12 @@ class QuizzesController < ApplicationController
 
   def case_correct
     create_answer_history(true, params[:answer_user_name], current_user.user_profile.id, params[:answer_user_id])
-    flash[:notice] = '正解！'
+    flash[:notice] = I18n.t("quiz.show.correct_result")
   end
 
   def case_incorrect
     create_answer_history(false, params[:answer_user_name], current_user.user_profile.id, params[:answer_user_id])
-    flash[:notice] = "不正解! 答えは#{@answer_user_profile.answer_name.to_s}です。"
+    flash[:notice] = I18n.t("quiz.show.incorrect_result", answer_name: @answer_user_profile.answer_name)
   end
 
   def create_answer_history(correct, answer, user_profile_id, to_user_profile_id)

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,7 @@
+class Answer < ActiveRecord::Base
+  belongs_to :user_profile
+  validates :user_profile_id, presence: true, numericality: true
+  validates :to_user_profile_id, presence: true, numericality: true
+  validates :correct, inclusion: { in: [true, false] }
+  validates :answer, length: { maximum: 30 }
+end

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -3,4 +3,16 @@ class UserProfile < ActiveRecord::Base
   delegate :name, to: :user
   validates :user_id, presence: true, numericality: true, uniqueness: true
   validates :answer_name, length: { maximum: 30 }
+
+  def answer_user
+    self.class.all.sample
+  end
+
+  def total_correct
+    Answer.where(correct: true, user_profile_id: self.id).count
+  end
+
+  def total_incorrect
+    Answer.where(correct: false, user_profile_id: self.id).count
+  end
 end

--- a/app/views/page/_user_profile.html.erb
+++ b/app/views/page/_user_profile.html.erb
@@ -5,4 +5,8 @@
   <li><%= current_user.email %></li>
 </ul>
 
-<%= link_to 'クイズを始める', quiz_path %>
+<% if @start_button_enabled %>
+  <%= link_to I18n.t('pages.index.start_quiz'), quiz_path %>
+<% else %>
+  <%= I18n.t('pages.index.can_not_start_quiz') %>
+<% end %>

--- a/app/views/quizzes/show.html.erb
+++ b/app/views/quizzes/show.html.erb
@@ -1,9 +1,18 @@
 <div style="border:1px solid black; width: 300px; height: 300px;" id="user_image"></div>
-<%= @user_profile.answer_name %>
+<%= @answer_user_profile.answer_name %>
 
 <%= form_tag answer_quiz_path do |f| %>
-  <%= hidden_field_tag :answer_user_id, @user_profile.id %>
+  <%= hidden_field_tag :answer_user_id, @answer_user_profile.id %>
   <%= label_tag :answer_user_name %>
   <%= text_field_tag :answer_user_name %>
   <%= submit_tag :answer %>
 <% end %>
+
+<div id="answer_results">
+  <span id="total_correct">
+    正解: <%= @total_correct %>
+  </span>
+  <span id="total_incorrect">
+    不正解: <%= @total_incorrect %>
+  </span>
+</div>

--- a/app/views/quizzes/show.html.erb
+++ b/app/views/quizzes/show.html.erb
@@ -10,9 +10,9 @@
 
 <div id="answer_results">
   <span id="total_correct">
-    正解: <%= @total_correct %>
+    <%= I18n.t('quiz.show.correct') %>: <%= @total_correct %>
   </span>
   <span id="total_incorrect">
-    不正解: <%= @total_incorrect %>
+    <%= I18n.t('quiz.show.incorrect') %>: <%= @total_incorrect %>
   </span>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,3 +6,8 @@ ja:
   layouts:
     application:
       submit_profile: "プロフィール登録"
+
+  pages:
+    index:
+      start_quiz: "クイズを始める"
+      can_not_start_quiz: "出題できるユーザーがいないため、今はクイズを始められません。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,3 +11,10 @@ ja:
     index:
       start_quiz: "クイズを始める"
       can_not_start_quiz: "出題できるユーザーがいないため、今はクイズを始められません。"
+
+  quiz:
+    show:
+      correct: "正解"
+      incorrect: "不正解"
+      incorrect_result: "不正解！ 正解は「%{answer_name}」さんです"
+      no_answer_users: "ユーザーがひとりも登録されていません。"

--- a/db/migrate/20150813035219_create_answers.rb
+++ b/db/migrate/20150813035219_create_answers.rb
@@ -1,0 +1,11 @@
+class CreateAnswers < ActiveRecord::Migration
+  def change
+    create_table :answers do |t|
+      t.references :user_profile
+      t.integer :user_profile_id, null: false
+      t.integer :to_user_profile_id, null: false
+      t.boolean :correct, null: false
+      t.string :answer, length: 30
+    end
+  end
+end

--- a/db/migrate/20150813044043_change_user_id_column_on_user_profiles.rb
+++ b/db/migrate/20150813044043_change_user_id_column_on_user_profiles.rb
@@ -1,7 +1,7 @@
 class ChangeUserIdColumnOnUserProfiles < ActiveRecord::Migration
   def change
+    change_column_null :user_profiles, :user_id, false
     remove_column :user_profiles, :first_name
     remove_column :user_profiles, :last_name
-    change_column_null :user_profiles, :user_id, false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,13 @@
 
 ActiveRecord::Schema.define(version: 20150813044043) do
 
+  create_table "answers", force: :cascade do |t|
+    t.integer "user_profile_id",    limit: 4,   null: false
+    t.integer "to_user_profile_id", limit: 4,   null: false
+    t.boolean "correct",                        null: false
+    t.string  "answer",             limit: 255
+  end
+
   create_table "user_profiles", force: :cascade do |t|
     t.integer  "user_id",     limit: 4,   null: false
     t.datetime "created_at",              null: false

--- a/spec/features/quizees_spec.rb
+++ b/spec/features/quizees_spec.rb
@@ -3,42 +3,61 @@ require 'rails_helper'
 feature "quiz page", type: :feature do
   feature '出題ページを表示' do
     include_context 'login_as_user'
-    let!(:target_users) { FactoryGirl.create_list :user, 10, :with_user_profile }
-    let!(:target_user_profile) { target_users.sample.user_profile }
+    let!(:answer_users) { FactoryGirl.create_list :user, 10, :with_user_profile }
+    let!(:answer_user_profile) { answer_users.sample.user_profile }
 
     background do
-      allow_any_instance_of(Array).to receive(:sample).and_return(target_user_profile)
+      allow_any_instance_of(Array).to receive(:sample).and_return(answer_user_profile)
     end
 
     scenario 'クイズの問題と解答欄が表示される' do
       visit quiz_path
+
       expect(page).to have_selector('#user_image')
       expect(page).to have_field('answer_user_name')
-      expect(find("#answer_user_id", visible: false).value.to_i).to eq target_user_profile.id
+      expect(find("#answer_user_id", visible: false).value.to_i).to eq answer_user_profile.id
     end
 
     feature '回答する' do
       context '正解の場合' do
-        scenario '回答したら結果が表示される' do
+        background do
           visit quiz_path
 
-          fill_in 'answer_user_name', with: target_user_profile.answer_name
+          fill_in 'answer_user_name', with: answer_user_profile.answer_name
           click_on 'answer'
+        end
 
-          expect(page).not_to have_content('不正解')
+        scenario '回答したら結果が表示される' do
+          expect(page).not_to have_css('div.notice', text: '不正解')
+        end
+
+        scenario '回答履歴に正解が記録される' do
+          expect(page).to have_css('#total_correct', '正解')
+          expect(page).to have_css('#total_correct', text: '1')
+
+          expect(login_user.user_profile.total_correct).to eq 1
         end
       end
 
       context '不正解の場合' do
         let(:answer_name) { Forgery(:basic).text }
 
-        scenario '回答したら結果が表示される' do
+        background do
           visit quiz_path
 
           fill_in 'answer_user_name', with: answer_name
           click_on 'answer'
+        end
 
-          expect(page).to have_content('不正解')
+        scenario '回答したら結果が表示される' do
+          expect(page).to have_css('div.notice', text: '不正解')
+        end
+
+        scenario '回答履歴に不正解が記録される' do
+          expect(page).to have_css('#total_incorrect', '不正解')
+          expect(page).to have_css('#total_incorrect', text: '1')
+
+          expect(login_user.user_profile.total_incorrect).to eq 1
         end
       end
     end

--- a/spec/features/quizees_spec.rb
+++ b/spec/features/quizees_spec.rb
@@ -28,11 +28,11 @@ feature "quiz page", type: :feature do
         end
 
         scenario '回答したら結果が表示される' do
-          expect(page).not_to have_css('div.notice', text: '不正解')
+          expect(page).not_to have_css('div.notice', text: I18n.t('quiz.show.incorrect'))
         end
 
         scenario '回答履歴に正解が記録される' do
-          expect(page).to have_css('#total_correct', '正解')
+          expect(page).to have_css('#total_correct', I18n.t('quiz.show.correct'))
           expect(page).to have_css('#total_correct', text: '1')
 
           expect(login_user.user_profile.total_correct).to eq 1
@@ -50,11 +50,11 @@ feature "quiz page", type: :feature do
         end
 
         scenario '回答したら結果が表示される' do
-          expect(page).to have_css('div.notice', text: '不正解')
+          expect(page).to have_css('div.notice', text: I18n.t('quiz.show.incorrect_result', answer_name: answer_user_profile.answer_name))
         end
 
         scenario '回答履歴に不正解が記録される' do
-          expect(page).to have_css('#total_incorrect', '不正解')
+          expect(page).to have_css('#total_incorrect', I18n.t('quiz.show.incorrect'))
           expect(page).to have_css('#total_incorrect', text: '1')
 
           expect(login_user.user_profile.total_incorrect).to eq 1

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Answer, type: :model do
+  it { should belong_to(:user_profile) }
+
+  it { should have_db_column(:user_profile_id).of_type(:integer) }
+  it { should validate_presence_of(:user_profile_id) }
+  it { validate_numericality_of(:user_profile_id) }
+
+  it { should have_db_column(:to_user_profile_id).of_type(:integer) }
+  it { should validate_presence_of(:to_user_profile_id) }
+  it { validate_numericality_of(:to_user_profile_id) }
+
+  it { should have_db_column(:answer).of_type(:string) }
+  it { should validate_length_of(:answer).is_at_most(30) }
+
+  it { should have_db_column(:correct).of_type(:boolean) }
+end


### PR DESCRIPTION
# 前提

 - game ブランチに依存

# 指摘への対応

- 必要なバリデーションと should matcher でのテストをを追加した (今回のコミットでは answersテーブルのみ )
- 必要な箇所にNOT NULL 制約をした (4択回答の時に必要かもしれないので、回答の文字列 answerカラムは NULL のまま)
- 文法を修正した
- i18nでパラメータを使用するようにした
- i18n にパラメータを渡している部分もテストするようにした
- 回答できるユーザーがいないときは、クイズ開始ボタンを非表示にするようにした
- ユーザーあたりの正解数・不正解数を、モデルに引数を渡すのではなく、UserProfile のメソッドから得られるように
- Contoroller での不要な to_s を削除
- Viewのユーザー用例外補足が必要なくなったのでコミットごと削除
- answer_user の存在チェックに .present? を使うように
