### PR TITLE
プロフィールに所属プロジェクト/グループなどを登録できるようにする

### DIFF
--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -3,6 +3,13 @@ class UserProfilesController < ApplicationController
 
   def edit
     @user_profile = UserProfile.find(params[:id])
+    @projects = Project.all
+    @groups = Group.all
+
+    @joined_years = []
+    for year in 2000..Time.zone.now.year do
+      @joined_years.unshift ["#{year}#{I18n.t('user_profiles.edit.year')}", year]
+    end
   end
 
   def update
@@ -26,7 +33,7 @@ class UserProfilesController < ApplicationController
   private
 
   def user_profile_params
-    params.require(:user_profile).permit(:answer_name)
+    params.require(:user_profile).permit(:answer_name, :gender, :group_id, :project_id, :joined_year, :detail)
   end
 
   def profile_image_params (target)

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -2,6 +2,6 @@ class Answer < ActiveRecord::Base
   belongs_to :user_profile
   validates :user_profile_id, presence: true, numericality: true
   validates :to_user_profile_id, presence: true, numericality: true
-  validates :correct, inclusion: { in: [true, false] }
+  validates :correct, inclusion: { in: [true, false, nil] }
   validates :answer, length: { maximum: 30 }
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,5 @@
+class Group < ActiveRecord::Base
+  has_many :user_profile
+
+  validates :name, presence: true
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,5 @@
+class Project < ActiveRecord::Base
+  has_many :user_profile
+
+  validates :name, presence: true
+end

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -1,9 +1,18 @@
 class UserProfile < ActiveRecord::Base
   belongs_to :user
   has_many :profile_images
+  belongs_to :project
+  belongs_to :group
+
   delegate :name, to: :user
+
   validates :user_id, presence: true, numericality: true, uniqueness: true
-  validates :answer_name, length: { maximum: 30 }
+  validates :answer_name, allow_nil: true, length: { maximum: 30 }
+  validates :group_id, allow_nil: true, numericality: true
+  validates :project_id, allow_nil: true, numericality: true
+  validates :gender, allow_nil: true, inclusion: { in: ['', 'male', 'female'] }
+  validates :joined_year, allow_nil: true, numericality: true
+  validates :detail, allow_nil: true, length: { maximum: 10000 }
 
   def answer_user
     self.class.all.sample

--- a/app/views/page/index.html.erb
+++ b/app/views/page/index.html.erb
@@ -3,5 +3,5 @@
 <% if current_user then %>
   <%= render partial: "user_profile" %>
 <% else %>
-  ログインしていません。<%= link_to 'Googleでログイン', user_omniauth_authorize_path(:google_oauth2) %>してください。
+  <%= link_to I18n.t('pages.index.please_login_with_google'), user_omniauth_authorize_path(:google_oauth2) %>
 <% end %>

--- a/app/views/user_profiles/edit.html.erb
+++ b/app/views/user_profiles/edit.html.erb
@@ -10,6 +10,26 @@
       <%= hidden_field "profile_image_#{situation}", :user_profile_id, value: @user_profile.id %>
     </div>
   <% end %>
+  <div>
+    <%= f.label I18n.t('user_profiles.edit.gender') %>
+    <%= f.select :gender, [[I18n.t('user_profiles.edit.male'), "male"], [I18n.t('user_profiles.edit.female'), "female"]], :selected => @user_profile.gender, include_blank: true %>
+  </div>
+  <div>
+    <%= f.label I18n.t('user_profiles.edit.project') %>
+    <%= f.select :project_id, options_from_collection_for_select(@projects, :id, :name, @user_profile.project_id), include_blank: true %>
+  </div>
+  <div>
+    <%= f.label I18n.t('user_profiles.edit.group') %>
+    <%= f.select :group_id, options_from_collection_for_select(@groups, :id, :name, @user_profile.group_id), include_blank: true %>
+  </div>
+  <div>
+    <%= f.label I18n.t('user_profiles.edit.joined_year') %>
+    <%= f.select :joined_year, @joined_years, selected: @user_profile.joined_year, include_blank: true %>
+  </div>
+  <div>
+    <%= f.label :detail, I18n.t('user_profiles.edit.detail') %>
+    <%= f.text_area :detail %>
+  </div>
   <%= f.submit %>
   </div>
 <% end %>

--- a/app/views/user_profiles/edit.html.erb
+++ b/app/views/user_profiles/edit.html.erb
@@ -1,5 +1,5 @@
 <%= form_for @user_profile, html: { multipart: true } do |f| %>
-  <%= f.label :answer_name %>
+  <%= f.label :answer_name, I18n.t('user_profiles.edit.answer_name') %>
   <%= f.text_field :answer_name %>
 
   <% @situations.each do |situation| %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,9 +1,5 @@
 ja:
 
-  pages:
-    index:
-      edit_profile: "プロフィールを編集する"
-
   user_profiles:
     update:
       flash_edited: "編集しました。"
@@ -11,6 +7,7 @@ ja:
       normal_image: "普通の写真（出題時）"
       succeed_image: "相手が正解した時の写真"
       failed_image: "相手が不正解した時の写真"
+      answer_name: "正解"
 
   layouts:
     application:
@@ -21,6 +18,7 @@ ja:
       start_quiz: "クイズを始める"
       can_not_start_quiz: "出題できるユーザーがいないため、今はクイズを始められません。"
       edit_profile: "プロフィールを編集する"
+      please_login_with_google: "こんにちは！ まずはGoogleでログインしてください。"
 
   quiz:
     show:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,6 +8,15 @@ ja:
       succeed_image: "相手が正解した時の写真"
       failed_image: "相手が不正解した時の写真"
       answer_name: "正解"
+      group: "グループ"
+      project: "所属プロジェクト"
+      joined_year: "入社年度"
+      detail: "その他のプロフィール"
+      gender: "性別"
+      male: "男性"
+      female: "女性"
+      please_select: "選択"
+      year: "年"
 
   layouts:
     application:

--- a/db/migrate/20150818091827_add_columns_to_user_profile_for_others.rb
+++ b/db/migrate/20150818091827_add_columns_to_user_profile_for_others.rb
@@ -1,0 +1,7 @@
+class AddColumnsToUserProfileForOthers < ActiveRecord::Migration
+  def change
+    add_column :user_profiles, :gender, :string
+    add_column :user_profiles, :joined_year, :integer
+    add_column :user_profiles, :detail, :text
+  end
+end

--- a/db/migrate/20150818101501_create_projects.rb
+++ b/db/migrate/20150818101501_create_projects.rb
@@ -1,0 +1,7 @@
+class CreateProjects < ActiveRecord::Migration
+  def change
+    create_table :projects do |t|
+      t.string :name, null: false
+    end
+  end
+end

--- a/db/migrate/20150819053334_add_references_to_user_profile.rb
+++ b/db/migrate/20150819053334_add_references_to_user_profile.rb
@@ -1,0 +1,6 @@
+class AddReferencesToUserProfile < ActiveRecord::Migration
+  def change
+    add_reference :user_profiles, :project, index: true
+    add_reference :user_profiles, :group, index: true
+  end
+end

--- a/db/migrate/20150819053414_create_groups.rb
+++ b/db/migrate/20150819053414_create_groups.rb
@@ -1,0 +1,7 @@
+class CreateGroups < ActiveRecord::Migration
+  def change
+    create_table :groups do |t|
+      t.string :name, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150814080251) do
+ActiveRecord::Schema.define(version: 20150818101501) do
 
   create_table "answers", force: :cascade do |t|
     t.integer "user_profile_id",    limit: 4,   null: false
@@ -28,11 +28,21 @@ ActiveRecord::Schema.define(version: 20150814080251) do
     t.datetime "updated_at",                  null: false
   end
 
+  create_table "projects", force: :cascade do |t|
+    t.integer "user_profile_id", limit: 4
+    t.string  "name",            limit: 255, null: false
+  end
+
   create_table "user_profiles", force: :cascade do |t|
     t.integer  "user_id",     limit: 4,   null: false
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
     t.string   "answer_name", limit: 255
+    t.integer  "group_id",    limit: 4
+    t.integer  "project_id",  limit: 4
+    t.string   "gender",      limit: 255
+    t.integer  "joined_year", limit: 4
+    t.string   "detail",      limit: 255
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150818101501) do
+ActiveRecord::Schema.define(version: 20150819053414) do
 
   create_table "answers", force: :cascade do |t|
     t.integer "user_profile_id",    limit: 4,   null: false
     t.integer "to_user_profile_id", limit: 4,   null: false
     t.boolean "correct",                        null: false
     t.string  "answer",             limit: 255
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string "name", limit: 255, null: false
   end
 
   create_table "profile_images", force: :cascade do |t|
@@ -29,21 +33,23 @@ ActiveRecord::Schema.define(version: 20150818101501) do
   end
 
   create_table "projects", force: :cascade do |t|
-    t.integer "user_profile_id", limit: 4
-    t.string  "name",            limit: 255, null: false
+    t.string "name", limit: 255, null: false
   end
 
   create_table "user_profiles", force: :cascade do |t|
-    t.integer  "user_id",     limit: 4,   null: false
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.integer  "user_id",     limit: 4,     null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
     t.string   "answer_name", limit: 255
-    t.integer  "group_id",    limit: 4
-    t.integer  "project_id",  limit: 4
     t.string   "gender",      limit: 255
     t.integer  "joined_year", limit: 4
-    t.string   "detail",      limit: 255
+    t.text     "detail",      limit: 65535
+    t.integer  "project_id",  limit: 4
+    t.integer  "group_id",    limit: 4
   end
+
+  add_index "user_profiles", ["group_id"], name: "index_user_profiles_on_group_id", using: :btree
+  add_index "user_profiles", ["project_id"], name: "index_user_profiles_on_project_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.datetime "created_at",                                      null: false

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :group do
+    name      { Forgery(:basic).text }
+  end
+end
+

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :project do
+    name      { Forgery(:basic).text }
+  end
+end
+

--- a/spec/features/page_spec.rb
+++ b/spec/features/page_spec.rb
@@ -8,7 +8,7 @@ feature "top page", type: :feature do
 
     context 'ログインしていない時' do
       scenario 'Googleへのログインリンクが表示される' do
-        expect(page).to have_link 'Googleでログイン', user_omniauth_authorize_path(:google_oauth2)
+        expect(page).to have_link I18n.t('pages.index.please_login_with_google'), user_omniauth_authorize_path(:google_oauth2)
       end
     end
 

--- a/spec/features/user_profiles_spec.rb
+++ b/spec/features/user_profiles_spec.rb
@@ -6,7 +6,18 @@ feature '登録者のプロフィール', type: :feature do
   feature 'プロフィールの編集' do
     let!(:user) { FactoryGirl.create :user, :with_user_profile }
     let!(:user_profile) { user.user_profile }
+    let!(:projects) { FactoryGirl.create_list :project, 5 }
+    let!(:groups) { FactoryGirl.create_list :group, 5 }
+
     let!(:new_answer_name) { Forgery(:name).full_name }
+    let!(:new_joined_year) { "#{Time.zone.now.year}#{I18n.t('user_profiles.edit.year')}" }
+    let!(:new_project) { projects.sample.name }
+    let!(:new_group) { groups.sample.name }
+    let!(:new_gender) { I18n.t('user_profiles.edit.male') }
+    let!(:new_detail) { Forgery(:basic).text }
+
+    let!(:edited_message) { I18n.t('user_profiles.update.flash_edited') }
+    let!(:update_button) { I18n.t('helpers.submit.update') }
 
     scenario 'プロフィールを表示できる' do
       visit edit_user_profile_path(user_profile)
@@ -21,12 +32,26 @@ feature '登録者のプロフィール', type: :feature do
 
       scenario 'プロフィールが編集できる' do
         fill_in 'user_profile_answer_name', with: new_answer_name
-        click_on I18n.t('helpers.submit.update')
+        select new_gender, from: 'user_profile_gender'
+        select new_joined_year, from: 'user_profile_joined_year'
+        select new_group, from: 'user_profile_group_id'
+        select new_project, from: 'user_profile_project_id'
+        fill_in 'user_profile_detail', with: new_detail
+
+        click_on update_button
 
         expect(current_path).to eq edit_user_profile_path(user_profile)
-        expect(page).to have_content I18n.t('user_profiles.update.flash_edited')
+
         expect(page).to have_field 'user_profile_answer_name', new_answer_name
+        expect(page).to have_select('user_profile_joined_year', selected: new_joined_year)
+        expect(page).to have_select('user_profile_gender', selected: new_gender)
+        expect(page).to have_select('user_profile_project_id', selected: new_project )
+        expect(page).to have_select('user_profile_group_id', selected: new_group )
+        expect(page).to have_field 'user_profile_detail', new_detail
+        expect(page).to have_content edited_message
+
         expect(UserProfile.find(user_profile.id).answer_name).to eq new_answer_name
+        expect(UserProfile.find(user_profile.id).detail).to eq new_detail
       end
 
       context '画像が添付された場合' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Group, type: :model do
+  it { should have_many(:user_profile) }
+
+  it { should have_db_column(:name).of_type(:string) }
+  it { should validate_presence_of(:name) }
+ end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Project, type: :model do
+  it { should have_many(:user_profile) }
+
+  it { should have_db_column(:name).of_type(:string) }
+  it { should validate_presence_of(:name) }
+end

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -1,7 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe UserProfile, type: :model do
-  it { should belong_to(:user) }
   it { should have_many(:profile_images) }
+  it { should belong_to(:user) }
+  it { should belong_to(:project) }
+
+  it { should have_db_column(:answer_name).of_type(:string) }
   it { should validate_length_of(:answer_name).is_at_most(30) }
+
+  it { should have_db_column(:group_id).of_type(:integer) }
+  it { should validate_numericality_of(:group_id) }
+
+  it { should have_db_column(:gender).of_type(:string) }
+
+  it { should have_db_column(:joined_year).of_type(:integer) }
+  it { should validate_numericality_of(:joined_year) }
+
+  it { should have_db_column(:detail).of_type(:text) }
+  it { should validate_length_of(:detail).is_at_most(10000) }
 end


### PR DESCRIPTION
# ご注意

複数の更新が混ざっていたため、プルリクを #18 と分けました。レビューへの対応は #18 でおこなっているものがあります。

# 内容

- 登録できるようにした項目
 - 所属プロジェクト
 - 所属グループ 
 - 性別
 - 入社年度
 - 自由入力欄

# 前提条件

- 所属グループ groups / 所属プロジェクト projects の内容は、運用上、SQLを直接発行して、手動でデータを作成します。
