### PR TITLE
出題のフィルタリングが出来るようにする

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -1,5 +1,6 @@
 class PageController < ApplicationController
   def index
-    @start_button_enabled = UserProfile.new.answer_user.present?
+    @projects = Project.all
+    @groups = Group.all
   end
 end

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,9 +1,15 @@
+
 class QuizzesController < ApplicationController
   def show
-    @answer_user_profile = UserProfile.new.answer_user
+    @answer_user_profile = UserProfile.answer_user(params, current_user.user_profile)
+
     @total_correct = current_user.user_profile.total_correct
     @total_incorrect = current_user.user_profile.total_incorrect
-    @profile_image_normal = ProfileImage.find_by(situation: :normal, user_profile_id: @answer_user_profile.id)
+
+    @start_button_enabled = @answer_user_profile.present?
+    @projects = Project.all
+    @groups = Group.all
+    @profile_image_normal = ProfileImage.find_by(situation: :normal, user_profile_id: @answer_user_profile.id) if @answer_user_profile
   end
 
   def answer
@@ -14,7 +20,7 @@ class QuizzesController < ApplicationController
     else
       case_incorrect
     end
-    redirect_to quiz_path
+    redirect_to quiz_path(params.permit(UserProfile.for_filter_params))
   end
 
   private

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -3,13 +3,6 @@ class UserProfilesController < ApplicationController
 
   def edit
     @user_profile = UserProfile.find(params[:id])
-    @projects = Project.all
-    @groups = Group.all
-
-    @joined_years = []
-    for year in 2000..Time.zone.now.year do
-      @joined_years.unshift ["#{year}#{I18n.t('user_profiles.edit.year')}", year]
-    end
   end
 
   def update

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def groups
+    Group.order('name ASC')
+  end
+
+  def projects
+    Project.order('name ASC')
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 module ApplicationHelper
+  def joined_years_selection
+    (1990..Time.zone.now.year+1).map { |year|
+      ["#{year}#{I18n.t('user_profiles.edit.year')}", year]
+    }.reverse
+  end
+
   def groups
     Group.order('name ASC')
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,11 @@
 </head>
 <body>
 
+<% if current_user then %>
+  <%= link_to 'TOP', root_path %>
+  <%= link_to I18n.t('pages.index.edit_profile'), edit_user_profile_path(current_user.id) %>
+<% end %>
+
 <% flash.each do |key, value| %>
   <%= content_tag(:div, value, class: "#{key}") %>
 <% end %>

--- a/app/views/page/_start_quiz.html.erb
+++ b/app/views/page/_start_quiz.html.erb
@@ -1,0 +1,21 @@
+<%= form_tag(quiz_path, method: 'get') do %>
+  <div>
+    <%= label :joined_year, I18n.t('pages.index.joined_year') %>
+    <%= select_tag :joined_year, options_for_select(joined_years_selection, selected: params['joined_year']), include_blank: true %>
+  </div>
+  <div>
+    <%= label :project_id, I18n.t('pages.index.project') %>
+    <%= select_tag :project_id, options_from_collection_for_select(@projects, :id, :name, selected: params['project_id']), include_blank: true %>
+  </div>
+  <div>
+    <%= label :group_id, I18n.t('pages.index.group') %>
+    <%= select_tag :group_id, options_from_collection_for_select(@groups, :id, :name, selected: params['group_id']), include_blank: true %>
+  </div>
+  <div>
+    <label>
+      <%= check_box_tag :review_mode, nil, params['review_mode'] %>
+      <%= label :review_mode, I18n.t('pages.index.review_mode') %>
+    <label>
+  </div>
+  <%= submit_tag I18n.t('pages.index.start_quiz') %>
+<% end %>

--- a/app/views/page/_user_profile.html.erb
+++ b/app/views/page/_user_profile.html.erb
@@ -4,11 +4,3 @@
   <li><%= current_user.uid %></li>
   <li><%= current_user.email %></li>
 </ul>
-
-<% if @start_button_enabled %>
-  <%= link_to I18n.t('pages.index.start_quiz'), quiz_path %>
-<% else %>
-  <%= I18n.t('pages.index.can_not_start_quiz') %>
-<% end %>
-
-<%= link_to I18n.t('pages.index.edit_profile'), edit_user_profile_path(current_user.user_profile.id) %>

--- a/app/views/page/index.html.erb
+++ b/app/views/page/index.html.erb
@@ -2,6 +2,7 @@
 
 <% if current_user then %>
   <%= render partial: "user_profile" %>
+  <%= render partial: "start_quiz" %>
 <% else %>
   <%= link_to I18n.t('pages.index.please_login_with_google'), user_omniauth_authorize_path(:google_oauth2) %>
 <% end %>

--- a/app/views/quizzes/show.html.erb
+++ b/app/views/quizzes/show.html.erb
@@ -1,20 +1,25 @@
-<div id="user_image">
-  <% if @profile_image_normal %>
-    <%= image_tag @profile_image_normal.image.url %>
+<% if @answer_user_profile %>
+  <div id="user_image">
+    <% if @profile_image_normal %>
+      <%= image_tag @profile_image_normal.image.url %>
+    <% end %>
+  </div>
+  <div>
+    <%= I18n.t('quiz.show.who') %>
+  </div>
+  <%= form_tag answer_quiz_path do |f| %>
+    <%= hidden_field_tag :answer_user_id, @answer_user_profile.id %>
+    <%= label_tag :answer_user_name %>
+    <%= text_field_tag :answer_user_name %>
+    <%= hidden_field_tag :joined_year, params[:joined_year] %>
+    <%= hidden_field_tag :project_id, params[:project_id] %>
+    <%= hidden_field_tag :group_id, params[:group_id] %>
+    <%= submit_tag :answer %>
   <% end %>
-</div>
-
-<div>
-  <%= I18n.t('quiz.show.who') %>
-</div>
-
-<%= @answer_user_profile.answer_name %>
-
-<%= form_tag answer_quiz_path do |f| %>
-  <%= hidden_field_tag :answer_user_id, @answer_user_profile.id %>
-  <%= label_tag :answer_user_name %>
-  <%= text_field_tag :answer_user_name %>
-  <%= submit_tag :answer %>
+<% else %>
+  <div>
+    <%= I18n.t('quiz.show.answer_user_not_found') %>
+  </div>
 <% end %>
 
 <div id="answer_results">
@@ -25,3 +30,5 @@
     <%= I18n.t('quiz.show.incorrect') %>: <%= @total_incorrect %>
   </span>
 </div>
+
+<%= render partial: "page/start_quiz" %>

--- a/app/views/user_profiles/edit.html.erb
+++ b/app/views/user_profiles/edit.html.erb
@@ -24,7 +24,7 @@
   </div>
   <div>
     <%= f.label I18n.t('user_profiles.edit.joined_year') %>
-    <%= f.select :joined_year, @joined_years, selected: @user_profile.joined_year, include_blank: true %>
+    <%= f.select :joined_year, joined_years_selection, selected: @user_profile.joined_year, include_blank: true %>
   </div>
   <div>
     <%= f.label :detail, I18n.t('user_profiles.edit.detail') %>

--- a/app/views/user_profiles/edit.html.erb
+++ b/app/views/user_profiles/edit.html.erb
@@ -16,11 +16,11 @@
   </div>
   <div>
     <%= f.label I18n.t('user_profiles.edit.project') %>
-    <%= f.select :project_id, options_from_collection_for_select(@projects, :id, :name, @user_profile.project_id), include_blank: true %>
+    <%= f.select :project_id, options_from_collection_for_select(projects, :id, :name, @user_profile.project_id), include_blank: true %>
   </div>
   <div>
     <%= f.label I18n.t('user_profiles.edit.group') %>
-    <%= f.select :group_id, options_from_collection_for_select(@groups, :id, :name, @user_profile.group_id), include_blank: true %>
+    <%= f.select :group_id, options_from_collection_for_select(groups, :id, :name, @user_profile.group_id), include_blank: true %>
   </div>
   <div>
     <%= f.label I18n.t('user_profiles.edit.joined_year') %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,22 +1,29 @@
 ja:
 
+  common: &common
+    joined_year: "入社年度"
+    group: "グループ"
+    project: "所属プロジェクト"
+    quiz: "クイズ"
+
   user_profiles:
     update:
       flash_edited: "編集しました。"
     edit:
-      normal_image: "普通の写真（出題時）"
-      succeed_image: "相手が正解した時の写真"
-      failed_image: "相手が不正解した時の写真"
       answer_name: "正解"
       group: "グループ"
       project: "所属プロジェクト"
       joined_year: "入社年度"
+      normal_image: "普通の写真（出題時）"
+      correct_image: "相手が正解した時の写真"
+      incorrect_image: "相手が不正解した時の写真"
       detail: "その他のプロフィール"
       gender: "性別"
       male: "男性"
       female: "女性"
       please_select: "選択"
       year: "年"
+      <<: *common
 
   layouts:
     application:
@@ -28,14 +35,18 @@ ja:
       can_not_start_quiz: "出題できるユーザーがいないため、今はクイズを始められません。"
       edit_profile: "プロフィールを編集する"
       please_login_with_google: "こんにちは！ まずはGoogleでログインしてください。"
+      review_mode: "間違った問題を復習する"
+      <<: *common
 
   quiz:
     show:
       correct: "正解"
       incorrect: "不正解"
+      correct_result: "正解！"
       incorrect_result: "不正解！ 正解は「%{answer_name}」さんです"
       no_answer_users: "ユーザーがひとりも登録されていません。"
       who: "これは誰？"
+      answer_user_not_found: "出題できるメンバーがいません。"
 
   errors:
     messages:

--- a/spec/factories/answers.rb
+++ b/spec/factories/answers.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :answer do
+    user_profile_id    { Forgery(:basic).number }
+    to_user_profile_id { [*1..3].sample }
+    answer             { Forgery(:basic).text }
+    correct            { Forgery(:basic).boolean }
+  end
+end

--- a/spec/factories/user_profiles.rb
+++ b/spec/factories/user_profiles.rb
@@ -1,5 +1,44 @@
 FactoryGirl.define do
   factory :user_profile do
     answer_name     { Forgery(:basic).text }
+    group_id        { [*1..3].sample }
+    project_id      { [*1..3].sample }
+    joined_year     { [Time.zone.now.year, Time.zone.now.year-1].sample }
+    gender          { ['male', 'female'].sample }
+
+    trait :with_user do
+      user { FactoryGirl.create :user }
+    end
+
+    trait :with_group do
+      after(:create) do |user_profile|
+        begin
+          FactoryGirl.create :group, id: user_profile.group_id
+        rescue
+        end
+      end
+    end
+
+    trait :with_project do
+      after(:create) do |user_profile|
+        begin
+          FactoryGirl.create :project, id: user_profile.project_id
+        rescue
+        end
+      end
+    end
+
+    trait :with_answer do
+      after(:create) do |user_profile|
+        FactoryGirl.create_list :answer, 10, user_profile_id: user_profile.id, to_user_profile_id: UserProfile.all.sample.id
+      end
+    end
+
+    trait :with_more_incorrect_answer do
+      after(:create) do |user_profile|
+        FactoryGirl.create_list :answer, 6, user_profile_id: user_profile.id, to_user_profile_id: UserProfile.all.sample.id, correct: false
+        FactoryGirl.create_list :answer, 4, user_profile_id: user_profile.id, to_user_profile_id: UserProfile.all.sample.id, correct: true
+      end
+    end
   end
 end

--- a/spec/features/page_spec.rb
+++ b/spec/features/page_spec.rb
@@ -2,18 +2,28 @@ require 'rails_helper'
 
 feature "top page", type: :feature do
   feature 'トップページを表示' do
-    background do
-      visit root_path
-    end
+    let!(:projects)          { FactoryGirl.create_list :project, 2 }
+    let!(:groups)            { FactoryGirl.create_list :group, 2 }
+    let!(:users)             { FactoryGirl.create_list :user, 10, :with_user_profile }
+
+    let(:joined_year_filter) { Time.zone.now.year }
+    let(:project_filter)     { projects.sample.name }
+    let(:group_filter)       { groups.sample.name }
 
     context 'ログインしていない時' do
       scenario 'Googleへのログインリンクが表示される' do
+        visit root_path
+
         expect(page).to have_link I18n.t('pages.index.please_login_with_google'), user_omniauth_authorize_path(:google_oauth2)
       end
     end
 
     context 'ログインしている時' do
       include_context 'login_as_user'
+
+      background do
+        visit root_path
+      end
 
       scenario '自分のユーザー情報が表示される' do
         expect(page).to have_content login_user.name
@@ -22,12 +32,20 @@ feature "top page", type: :feature do
         expect(page).to have_content login_user.email
       end
 
-      scenario 'クイズ開始リンクが表示される' do
-        expect(page).to have_link 'クイズを始める', quiz_path
+      scenario 'クイズ開始フォームが表示される' do
+        expect(page).to have_select('joined_year')
+        expect(page).to have_select('project_id')
+        expect(page).to have_select('group_id')
+        expect(page).to have_button I18n.t('pages.index.start_quiz')
+
+        select joined_year_filter, from: 'joined_year'
+        select project_filter, from: 'project_id'
+        select group_filter, from: 'group_id'
       end
 
-      scenario 'プロフィール編集ページへの リンクが表示される' do
-        expect(page).to have_link I18n.t('pages.index.edit_profile'), edit_user_profile_path(login_user.user_profile.id)
+      scenario 'クイズ開始ボタンを押すと出題ページに移動する' do
+        click_on I18n.t('pages.index.start_quiz')
+        expect(current_path).to eq quiz_path
       end
     end
   end

--- a/spec/features/quizees_spec.rb
+++ b/spec/features/quizees_spec.rb
@@ -3,63 +3,90 @@ require 'rails_helper'
 feature "quiz page", type: :feature do
   feature '出題ページを表示' do
     include_context 'login_as_user'
-    let!(:answer_users) { FactoryGirl.create_list :user, 10, :with_user_profile }
-    let!(:answer_user_profile) { answer_users.sample.user_profile }
 
-    background do
-      allow_any_instance_of(Array).to receive(:sample).and_return(answer_user_profile)
-    end
+    let!(:user_profiles) { FactoryGirl.create_list :user_profile, 30, :with_user, :with_group, :with_project }
 
-    scenario 'クイズの問題と解答欄が表示される' do
-      visit quiz_path
+    context '基本項目でフィルタする場合' do
+      let(:filter_user_profile) { user_profiles.sample }
+      let(:joined_year_filter) { filter_user_profile.joined_year }
+      let(:group_id_filter) { filter_user_profile.group_id }
+      let(:project_id_filter) { filter_user_profile.project_id }
+      let(:filters){ { 'joined_year' => joined_year_filter, 'group_id' => group_id_filter, 'project_id' => project_id_filter } }
 
-      expect(page).to have_selector('#user_image')
-      expect(page).to have_field('answer_user_name')
-      expect(find("#answer_user_id", visible: false).value.to_i).to eq answer_user_profile.id
-    end
+      let!(:answer_user_profile) { UserProfile.answer_user(filters, login_user.user_profile) }
 
-    feature '回答する' do
-      context '正解の場合' do
-        background do
-          visit quiz_path
+      background do
+        allow(UserProfile).to receive_message_chain(:answer_user).and_return(answer_user_profile)
 
-          fill_in 'answer_user_name', with: answer_user_profile.answer_name
-          click_on 'answer'
-        end
-
-        scenario '回答したら結果が表示される' do
-          expect(page).not_to have_css('div.notice', text: I18n.t('quiz.show.incorrect'))
-        end
-
-        scenario '回答履歴に正解が記録される' do
-          expect(page).to have_css('#total_correct', I18n.t('quiz.show.correct'))
-          expect(page).to have_css('#total_correct', text: '1')
-
-          expect(login_user.user_profile.total_correct).to eq 1
-        end
+        visit quiz_path(filters)
       end
 
-      context '不正解の場合' do
-        let(:answer_name) { Forgery(:basic).text }
+      scenario 'クイズの問題と解答欄が表示される' do
+        expect(page).to have_selector('#user_image')
+        expect(page).to have_field('answer_user_name')
+        expect(find("#answer_user_id", visible: false).value.to_i).to eq answer_user_profile.id
+      end
 
-        background do
-          visit quiz_path
+      feature '回答する' do
+        context '正解の場合' do
+          background do
+            fill_in 'answer_user_name', with: answer_user_profile.answer_name
+            click_on 'answer'
+          end
 
-          fill_in 'answer_user_name', with: answer_name
-          click_on 'answer'
+          scenario '回答したら結果が表示される' do
+            expect(page).not_to have_css('div.notice', text: I18n.t('quiz.show.incorrect'))
+          end
+
+          scenario '回答履歴に正解が記録される' do
+            expect(page).to have_css('#total_correct', I18n.t('quiz.show.correct'))
+            expect(page).to have_css('#total_correct', text: '1')
+
+            expect(login_user.user_profile.total_correct).to eq 1
+          end
         end
 
-        scenario '回答したら結果が表示される' do
-          expect(page).to have_css('div.notice', text: I18n.t('quiz.show.incorrect_result', answer_name: answer_user_profile.answer_name))
-        end
+        context '不正解の場合' do
+          let(:answer_name) { Forgery(:basic).text }
 
-        scenario '回答履歴に不正解が記録される' do
-          expect(page).to have_css('#total_incorrect', I18n.t('quiz.show.incorrect'))
-          expect(page).to have_css('#total_incorrect', text: '1')
+          background do
+            visit quiz_path
 
-          expect(login_user.user_profile.total_incorrect).to eq 1
+            fill_in 'answer_user_name', with: answer_name
+            click_on 'answer'
+          end
+
+          scenario '回答したら結果が表示される' do
+            expect(page).to have_css('div.notice', text: I18n.t('quiz.show.incorrect_result', answer_name: answer_user_profile.answer_name))
+          end
+
+          scenario '回答履歴に不正解が記録される' do
+            expect(page).to have_css('#total_incorrect', I18n.t('quiz.show.incorrect'))
+            expect(page).to have_css('#total_incorrect', text: '1')
+
+            expect(login_user.user_profile.total_incorrect).to eq 1
+          end
         end
       end
+    end
+
+    context '復習モードでフィルタする場合' do
+      let!(:user_profile){ user_profiles.sample }
+      let!(:filters){ { 'review_mode' => 1 } }
+      let!(:answers) { FactoryGirl.create_list :answer, 30, user_profile_id: user_profile.id, correct: false }
+      let!(:answer_user_profile) { UserProfile.answer_user(filters, user_profile) }
+
+      background do
+        allow(UserProfile).to receive_message_chain(:answer_user).and_return(answer_user_profile)
+      end
+
+      # TODO: 未完成
+      # context '出題できるものがある場合' do
+      #   scenario '出題のフィルタリングが出来ている' do
+      #     visit quiz_path(filters)
+      #     expect(find("#answer_user_id", visible: false).value.to_i).to eq answer_user_profile.id
+      #   end
+      # end
     end
   end
 end

--- a/spec/features/user_profiles_spec.rb
+++ b/spec/features/user_profiles_spec.rb
@@ -4,28 +4,28 @@ feature '登録者のプロフィール', type: :feature do
   include_context 'login_as_user'
 
   feature 'プロフィールの編集' do
-    let!(:user) { FactoryGirl.create :user, :with_user_profile }
-    let!(:user_profile) { user.user_profile }
-    let!(:projects) { FactoryGirl.create_list :project, 5 }
-    let!(:groups) { FactoryGirl.create_list :group, 5 }
+    let!(:user)           { FactoryGirl.create :user, :with_user_profile }
+    let!(:user_profile)   { user.user_profile }
+    let!(:projects)       { FactoryGirl.create_list :project, 5 }
+    let!(:groups)         { FactoryGirl.create_list :group, 5 }
 
-    let!(:new_answer_name) { Forgery(:name).full_name }
-    let!(:new_joined_year) { "#{Time.zone.now.year}#{I18n.t('user_profiles.edit.year')}" }
-    let!(:new_project) { projects.sample.name }
-    let!(:new_group) { groups.sample.name }
-    let!(:new_gender) { I18n.t('user_profiles.edit.male') }
-    let!(:new_detail) { Forgery(:basic).text }
-
-    let!(:edited_message) { I18n.t('user_profiles.update.flash_edited') }
-    let!(:update_button) { I18n.t('helpers.submit.update') }
-
-    scenario 'プロフィールを表示できる' do
+   scenario 'プロフィールを表示できる' do
       visit edit_user_profile_path(user_profile)
 
       expect(page).to have_field 'user_profile_answer_name', login_user.user_profile.answer_name
     end
 
     feature 'プロフィールが編集できる' do
+      let(:new_answer_name) { Forgery(:name).full_name }
+      let(:new_joined_year) { "#{Time.zone.now.year}#{I18n.t('user_profiles.edit.year')}" }
+      let(:new_project)     { projects.sample.name }
+      let(:new_group)       { groups.sample.name }
+      let(:new_gender)      { I18n.t('user_profiles.edit.male') }
+      let(:new_detail)      { Forgery(:basic).text }
+
+      let(:edited_message)  { I18n.t('user_profiles.update.flash_edited') }
+      let(:update_button)   { I18n.t('helpers.submit.update') }
+
       background do
         visit edit_user_profile_path(user_profile)
       end

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -18,4 +18,58 @@ RSpec.describe UserProfile, type: :model do
 
   it { should have_db_column(:detail).of_type(:text) }
   it { should validate_length_of(:detail).is_at_most(10000) }
+
+  describe '.answer_user (condition, user_profile)' do
+    let!(:user_profiles) { FactoryGirl.create_list :user_profile, 10, :with_user, :with_group, :with_project }
+
+    context '入社年度でフィルタする場合' do
+      let(:filter_joined_year)  { user_profiles.sample.joined_year }
+      let(:answer_user_profile) { UserProfile.answer_user({'joined_year' => filter_joined_year }) }
+
+      it 'condition { joined_year => $joined_year }' do
+        expect(answer_user_profile.joined_year).to eq filter_joined_year
+      end
+    end
+
+    context '所属プロジェクトでフィルタする場合' do
+      let(:filter_project_id)   { user_profiles.sample.project_id }
+      let(:answer_user_profile) { UserProfile.answer_user({'project_id' => filter_project_id }) }
+
+      it 'condition{ project_id => $project_id }' do
+        expect(answer_user_profile.project_id).to eq filter_project_id
+      end
+    end
+
+    context '所属グループでフィルタする場合' do
+      let(:filter_group_id)     { user_profiles.sample.group_id }
+      let(:answer_user_profile) { UserProfile.answer_user({'group_id' => filter_group_id }) }
+
+      it 'condition { group_id => $group_id }' do
+        expect(answer_user_profile.group_id).to eq filter_group_id
+      end
+    end
+
+    context 'filter by review_mdoe' do
+      let(:user_profile)        { user_profiles.sample }
+      let(:answer_user_profile) { UserProfile.answer_user({'review_mdoe' => 1 }, user_profile) }
+      let(:answers)             { FactoryGirl.create_list :answer, 30, user_profile_id: user_profile.id }
+
+      it 'condition { review_mdoe => 1 }' do
+      end
+    end
+  end
+
+  describe '#review_mode_user_profile_ids(user_profile)' do
+    let!(:user_profiles)    { FactoryGirl.create_list :user_profile, 20, :with_user, :with_more_incorrect_answer }
+    let!(:user_profile)     { user_profiles.sample }
+    let!(:user_profile_ids) { user_profile.review_mode_user_profile_ids }
+
+    it '得たIDすべてにおいて、不正解数が正解数以上になっている' do
+      user_profile_ids.each do |id|
+        correct_num = Answer.count(user_profile_id: user_profile.id, to_user_profile_id: id, correct: true)
+        incorrect_num = Answer.count(user_profile_id: user_profile.id, to_user_profile_id: id, correct: false)
+        expect(incorrect_num).to be >= correct_num
+      end
+    end
+  end
 end

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -1,9 +1,8 @@
 shared_context "setup_OmniAuth_config" do |service|
   before do
     OmniAuth.config.test_mode = true
-
     oauthinfo = {
-      uid:    Forgery(:basic).number,
+      uid:    Forgery(:basic).number(:at_least => 1, :at_most => 999999999999999999999),
       name:   Forgery(:name).full_name,
       email:  Forgery(:email).address,
       token:  Forgery(:basic).encrypt,


### PR DESCRIPTION
# フィルタできるようにする項目
 - 所属プロジェクト
 - 所属グループ 
 - 入社年度
 - 過去に不正解だった問題 (正解数より不正解数が多いもの)

# 指摘への対応

- alel_table で書いていた部分を、whereで書くようにした
- モックの書き方を変えた（「書き換えるメソッドの範囲」を限定した）
- each の迂遠な書き方を map に変えた
- view用に、controllerで変数を使ってたい部分を、view helper に書くようにした
-（コミット含めるのが適切でない）デバッグ用の記述を削除した
- プロフィール編集ページで、プロジェクト名・グループ名がアルファベット順に並ぶようにした
- クラスメソッド/インスタンスメソッドの使い方を適切なものに変えた

# 調査中
- FactoryGirl の traits の書き方 

# その他

- コミットがほとんど分割されておらず、すいません。