### PR TITLE
デプロイ設定を修正する(2)

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -3,7 +3,7 @@ set :rails_env, :production
 
 server 'jagi', user: 'jagi', roles: %w{web app db}
 
-set :linked_dirs, %w{log tmp/pids tmp/sockets public}
+set :linked_dirs, %w{log tmp/pids tmp/sockets public/assets public/uploads}
 
 set :ssh_options, {
   forward_agent: true,


### PR DESCRIPTION
- public/uploads を shared にリンクするようにした

( public 直下だけの指定だと、 uploads や assets ディレクトリが自動的に生成されなかった )